### PR TITLE
Adds classification_labels and target_type

### DIFF
--- a/schemas/trained_model.schema.json
+++ b/schemas/trained_model.schema.json
@@ -107,7 +107,6 @@
       },
       "required": [
         "tree_structure",
-        "target_type",
         "feature_names"
       ]
     },
@@ -193,12 +192,7 @@
             }
           ]
         }
-      },
-      "required": [
-        "target_type",
-        "trained_models",
-        "feature_names"
-      ]
+      }
     }
   },
   "oneOf": [


### PR DESCRIPTION
Discussed with @tveasey and @droberts195 around how to determine classification vs regression and how to encode the classification labels. 

we determined that models should have `target_type` indicating `classification` vs `regression` so that inference knows how to handle the target values and if probabilities are supported or not. 

Additionally, we need the `classification_labels`. 

Notes:

* I think all models should have `feature_names` associated with them. Even if they are part of the ensemble. But, the feature_names value would be the same as the parent ensemble class. I think this is that each type of model that COULD be used in an ensemble should be able to be used by itself. 
* `classification_labels` is not required as the data provided to the training process could already have ordinal encoded labels
* `target_type` I think that all models should have this (even ones part of an ensemble). This does not really effect anything except at the top level since the ensemble will combine the raw responses from the sub-models anyways. 


Let me know what you think @valeriy42 !