### PR TITLE
Add number samples per node

### DIFF
--- a/examples/ensemble_example.json
+++ b/examples/ensemble_example.json
@@ -68,15 +68,18 @@
                 "decision_type": "lte",
                 "default_left": true,
                 "left_child": 1,
-                "right_child": 2
+                "right_child": 2,
+                "number_samples": 10
               },
               {
                 "node_index": 1,
-                "leaf_value": 1
+                "leaf_value": 1,
+                "number_samples": 8
               },
               {
                 "node_index": 2,
-                "leaf_value": 2
+                "leaf_value": 2,
+                "number_samples": 2
               }
             ],
             "target_type": "regression"
@@ -98,15 +101,18 @@
                 "decision_type": "lte",
                 "default_left": true,
                 "left_child": 1,
-                "right_child": 2
+                "right_child": 2,
+                "number_samples": 10
               },
               {
                 "node_index": 1,
-                "leaf_value": 1
+                "leaf_value": 1,
+                "number_samples": 5
               },
               {
                 "node_index": 2,
-                "leaf_value": 2
+                "leaf_value": 2,
+                "number_samples": 5
               }
             ],
             "target_type": "regression"

--- a/examples/tree_example.json
+++ b/examples/tree_example.json
@@ -49,15 +49,18 @@
           "decision_type": "lte",
           "default_left": true,
           "left_child": 1,
-          "right_child": 2
+          "right_child": 2,
+          "number_samples": 10
         },
         {
           "node_index": 1,
-          "leaf_value": 1
+          "leaf_value": 1,
+          "number_samples": 8
         },
         {
           "node_index": 2,
-          "leaf_value": 2
+          "leaf_value": 2,
+          "number_samples": 2
         }
       ],
       "target_type": "regression"

--- a/schemas/model_definition.schema.json
+++ b/schemas/model_definition.schema.json
@@ -66,6 +66,10 @@
         },
         "right_child": {
           "type": "integer"
+        },
+        "number_samples": {
+          "description": "Number of training samples that were affected by the node.",
+          "type": "integer"
         }
       },
       "required": [

--- a/schemas/model_definition.schema.json
+++ b/schemas/model_definition.schema.json
@@ -79,7 +79,8 @@
         "decision_type",
         "default_left",
         "left_child",
-        "right_child"
+        "right_child",
+        "number_samples"
       ],
       "additionalProperties": false
     },
@@ -92,11 +93,16 @@
         },
         "leaf_value": {
           "type": "number"
+        },
+        "number_samples": {
+          "description": "Number of training samples that were affected by the node.",
+          "type": "integer"
         }
       },
       "required": [
         "node_index",
-        "leaf_value"
+        "leaf_value",
+        "number_samples"
       ],
       "additionalProperties": false
     },


### PR DESCRIPTION
I suggest to add the "number_samples" as a required parameter for tree nodes and leaf nodes. The parameter describes how many training samples were affected by a node (aka passed through a node).

This information is required for computation of feature importance values using SHAP Algorithm. It also potentially allows one to compute "coverage" information (used e.g. in XGBoost). 