### PR TITLE
Add minItems property to feature_names

### DIFF
--- a/examples/ensemble_example.json
+++ b/examples/ensemble_example.json
@@ -37,10 +37,7 @@
     "ensemble": {
       "feature_names": [
         "col1_male",
-        "col1_female",
-        "col2_encoded",
-        "col3_encoded",
-        "col4"
+        "col2_encoded"
       ],
       "aggregate_output": {
         "weighted_sum": {
@@ -55,9 +52,7 @@
         {
           "tree": {
             "feature_names": [
-              "col1_male",
-              "col1_female",
-              "col4"
+              "col1_male"
             ],
             "tree_structure": [
               {
@@ -88,9 +83,7 @@
         {
           "tree": {
             "feature_names": [
-              "col2_encoded",
-              "col3_encoded",
-              "col4"
+              "col2_encoded"
             ],
             "tree_structure": [
               {

--- a/examples/tree_example.json
+++ b/examples/tree_example.json
@@ -36,9 +36,7 @@
   "trained_model": {
     "tree": {
       "feature_names": [
-        "col1_male",
-        "col1_female",
-        "col4"
+        "col1_male"
       ],
       "tree_structure": [
         {

--- a/schemas/model_definition.schema.json
+++ b/schemas/model_definition.schema.json
@@ -21,10 +21,10 @@
         "feature_names": {
           "type": "array",
           "items": {
-            "type": "string",
-            "minItems": 0,
-            "uniqueItems": true
-          }
+            "type": "string"
+          },
+          "minItems": 0,
+          "uniqueItems": true
         },
         "classification_labels": {
           "items": {
@@ -115,10 +115,10 @@
         "feature_names": {
           "type": "array",
           "items": {
-            "type": "string",
-            "minItems": 0,
-            "uniqueItems": true
-          }
+            "type": "string"
+          },
+          "minItems": 0,
+          "uniqueItems": true
         },
         "tree_structure": {
           "type": "array",
@@ -159,10 +159,10 @@
         "feature_names": {
           "type": "array",
           "items": {
-            "type": "string",
-            "minItems": 0,
-            "uniqueItems": true
-          }
+            "type": "string"
+          },
+          "minItems": 0,
+          "uniqueItems": true
         },
         "trained_models": {
           "type": "array",
@@ -389,35 +389,35 @@
           {
             "properties": {
               "one_hot_encoding": {
-                "$ref": "#/definitions/one_hot_encoding" 
+                "$ref": "#/definitions/one_hot_encoding"
               }
             },
             "required": [
               "one_hot_encoding"
             ],
-            "additionalProperties": false 
+            "additionalProperties": false
           },
           {
             "properties": {
               "target_mean_encoding": {
-                "$ref": "#/definitions/target_mean_encoding" 
+                "$ref": "#/definitions/target_mean_encoding"
               }
             },
             "required": [
               "target_mean_encoding"
             ],
-            "additionalProperties": false 
+            "additionalProperties": false
           },
           {
             "properties": {
               "frequency_encoding": {
-                "$ref": "#/definitions/frequency_encoding" 
+                "$ref": "#/definitions/frequency_encoding"
               }
             },
             "required": [
               "frequency_encoding"
             ],
-            "additionalProperties": false 
+            "additionalProperties": false
           }
         ]
       },

--- a/schemas/model_definition.schema.json
+++ b/schemas/model_definition.schema.json
@@ -21,7 +21,9 @@
         "feature_names": {
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "string",
+            "minItems": 0,
+            "uniqueItems": true
           }
         },
         "classification_labels": {
@@ -113,7 +115,9 @@
         "feature_names": {
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "string",
+            "minItems": 0,
+            "uniqueItems": true
           }
         },
         "tree_structure": {
@@ -155,7 +159,9 @@
         "feature_names": {
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "string",
+            "minItems": 0,
+            "uniqueItems": true
           }
         },
         "trained_models": {


### PR DESCRIPTION
This PR adds `minItems` property to the `feature_names` arrays and sets it to 0. This makes it explicit that it is allowed for the array to be empty (e.g. in case of decision tree stumps). Furthermore, the update enforces the feature names to be distinct.

I also updated the examples to make sense, since we want only the feature names to be listed, which are really used by the trained models.